### PR TITLE
Use shared file-size limit for media processing

### DIFF
--- a/services/media_processor.py
+++ b/services/media_processor.py
@@ -8,6 +8,7 @@ import tempfile
 from typing import Optional, Dict, Any
 from telegram import Message
 from telegram.ext import ContextTypes
+from config import MAX_FILE_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,6 @@ class MediaProcessor:
     
     # Поддерживаемые типы файлов
     SUPPORTED_DOCUMENT_TYPES = ['.xlsx', '.xls', '.pdf']
-    MAX_FILE_SIZE = 1024 * 1024  # 1 MB
     
     def __init__(self):
         self.temp_files = []  # Для отслеживания временных файлов
@@ -105,11 +105,11 @@ class MediaProcessor:
             document = message.document
             
             # Проверяем размер файла
-            if document.file_size and document.file_size > self.MAX_FILE_SIZE:
+            if document.file_size and document.file_size > MAX_FILE_SIZE:
                 logger.warning(f"Файл слишком большой: {document.file_size} байт")
                 return {
                     'type': 'document',
-                    'error': f'Файл слишком большой. Максимальный размер: {self.MAX_FILE_SIZE // 1024} KB'
+                    'error': f'Файл слишком большой. Максимальный размер: {MAX_FILE_SIZE // (1024 * 1024)} MB'
                 }
             
             # Проверяем тип файла

--- a/tests/test_media_processor_file_size.py
+++ b/tests/test_media_processor_file_size.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Тест проверки ограничения размера файлов в MediaProcessor"""
+import asyncio
+import sys
+import os
+from types import SimpleNamespace
+
+# Добавляем корень проекта в путь
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Устанавливаем необходимые переменные окружения для импорта config
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'test')
+os.environ.setdefault('OPENAI_API_KEY', 'test')
+os.environ.setdefault('SUPABASE_URL', 'test')
+os.environ.setdefault('SUPABASE_KEY', 'test')
+
+from services.media_processor import MediaProcessor
+from config import MAX_FILE_SIZE
+
+class DummyFile:
+    async def download_to_drive(self, dest):
+        with open(dest, 'wb') as f:
+            f.write(b'')
+
+class DummyBot:
+    async def get_file(self, file_id):
+        return DummyFile()
+
+def create_message(size):
+    document = SimpleNamespace(file_id="file", file_size=size,
+                               file_name="test.pdf", mime_type="application/pdf")
+    return SimpleNamespace(document=document, photo=None, voice=None, caption=None)
+
+async def test_file_size():
+    processor = MediaProcessor()
+    context = SimpleNamespace(bot=DummyBot())
+
+    small_message = create_message(5 * 1024 * 1024)  # 5MB
+    large_message = create_message(55 * 1024 * 1024)  # 55MB
+
+    small_result = await processor._process_document(small_message, context)
+    large_result = await processor._process_document(large_message, context)
+
+    assert 'error' not in small_result, "5MB file should be accepted"
+    assert 'error' in large_result, "55MB file should be rejected"
+
+    print("5MB result:", small_result)
+    print("55MB result:", large_result)
+
+if __name__ == "__main__":
+    asyncio.run(test_file_size())
+


### PR DESCRIPTION
## Summary
- import `MAX_FILE_SIZE` from `config` instead of using a local constant
- validate documents against the shared limit and report size in MB
- add a test ensuring 5MB files pass and 55MB files are rejected

## Testing
- `python tests/test_media_processor_file_size.py`


------
https://chatgpt.com/codex/tasks/task_e_68be1b8246e0832ca7ad34c0e23a311e