### PR TITLE
Ensure media cleanup

### DIFF
--- a/services/media_processor.py
+++ b/services/media_processor.py
@@ -23,20 +23,22 @@ class MediaProcessor:
     
     async def process_media_message(self, message: Message, context: ContextTypes.DEFAULT_TYPE) -> Optional[Dict[str, Any]]:
         """Обрабатывает медиа сообщение и возвращает результат"""
+        result: Optional[Dict[str, Any]] = None
         try:
             if message.photo:
-                return await self._process_photo(message, context)
+                result = await self._process_photo(message, context)
             elif message.voice:
-                return await self._process_voice(message, context)
+                result = await self._process_voice(message, context)
             elif message.document:
-                return await self._process_document(message, context)
+                result = await self._process_document(message, context)
             else:
                 logger.warning(f"Неподдерживаемый тип медиа: {message.content_type}")
-                return None
-                
         except Exception as e:
             logger.error(f"Ошибка при обработке медиа: {e}")
-            return None
+        finally:
+            self.cleanup_temp_files()
+        return result
+
     
     async def _process_photo(self, message: Message, context: ContextTypes.DEFAULT_TYPE) -> Optional[Dict[str, Any]]:
         """Обрабатывает фотографию"""

--- a/tests/test_media_processor_cleanup.py
+++ b/tests/test_media_processor_cleanup.py
@@ -1,0 +1,74 @@
+import os
+import tempfile
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from services.media_processor import MediaProcessor
+
+
+class DummyFile:
+    async def download_to_drive(self, path: str) -> None:
+        with open(path, "wb") as f:
+            f.write(b"data")
+
+
+class DummyBot:
+    async def get_file(self, file_id: str) -> DummyFile:  # type: ignore
+        return DummyFile()
+
+
+class DummyContext:
+    def __init__(self) -> None:
+        self.bot = DummyBot()
+
+
+class DummyPhoto:
+    file_id = "id"
+    file_size = 10
+    width = 1
+    height = 1
+
+
+class DummyVoice:
+    file_id = "id"
+    file_size = 10
+    duration = 1
+
+
+class DummyDocument:
+    file_id = "id"
+    file_size = 10
+    file_name = "file.pdf"
+    mime_type = "application/pdf"
+
+
+def make_message(kind: str):
+    if kind == "photo":
+        return SimpleNamespace(photo=[DummyPhoto()], voice=None, document=None, caption="", content_type="photo")
+    if kind == "voice":
+        return SimpleNamespace(photo=[], voice=DummyVoice(), document=None, caption="", content_type="voice")
+    if kind == "document":
+        return SimpleNamespace(photo=[], voice=None, document=DummyDocument(), caption="", content_type="document")
+    raise ValueError(kind)
+
+
+@pytest.mark.parametrize("kind", ["photo", "voice", "document"])
+def test_process_media_message_cleanup(kind: str):
+    processor = MediaProcessor()
+    context = DummyContext()
+    message = make_message(kind)
+
+    tmp_dir = tempfile.gettempdir()
+    before = set(os.listdir(tmp_dir))
+    result = asyncio.run(processor.process_media_message(message, context))
+    after = set(os.listdir(tmp_dir))
+
+    assert result is not None
+    assert result["file_path"].startswith(tmp_dir)
+    assert not os.path.exists(result["file_path"])
+    assert before == after
+    assert processor.temp_files == []


### PR DESCRIPTION
## Summary
- call `cleanup_temp_files` after processing media messages
- add tests ensuring no temporary files remain after processing photo, voice, or document

## Testing
- `pytest tests/test_media_processor_cleanup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be1b7ed820832cab72bdc18e379389