### PR TITLE
Add media processing stubs and manual media tests

### DIFF
--- a/services/media_processor.py
+++ b/services/media_processor.py
@@ -17,9 +17,29 @@ class MediaProcessor:
     # Поддерживаемые типы файлов
     SUPPORTED_DOCUMENT_TYPES = ['.xlsx', '.xls', '.pdf']
     MAX_FILE_SIZE = 1024 * 1024  # 1 MB
-    
+
     def __init__(self):
         self.temp_files = []  # Для отслеживания временных файлов
+
+    async def voice_to_text(self, file_path: str) -> str:
+        """Преобразует голосовое сообщение в текст"""
+        logger.warning("voice_to_text заглушка: функциональность не реализована")
+        return ""
+
+    async def audio_to_text(self, file_path: str) -> str:
+        """Преобразует аудио файл в текст"""
+        logger.warning("audio_to_text заглушка: функциональность не реализована")
+        return ""
+
+    async def image_to_text(self, file_path: str) -> str:
+        """Извлекает текст из изображения"""
+        logger.warning("image_to_text заглушка: функциональность не реализована")
+        return ""
+
+    async def pdf_to_text(self, file_path: str) -> str:
+        """Извлекает текст из PDF документа"""
+        logger.warning("pdf_to_text заглушка: функциональность не реализована")
+        return ""
     
     async def process_media_message(self, message: Message, context: ContextTypes.DEFAULT_TYPE) -> Optional[Dict[str, Any]]:
         """Обрабатывает медиа сообщение и возвращает результат"""

--- a/tests/test_media_messages.py
+++ b/tests/test_media_messages.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Тест обработки голосовых и фото сообщений через MessageProcessor.
+Проверяет, что заглушки MediaProcessor работают без исключений.
+"""
+
+import asyncio
+from types import SimpleNamespace
+import sys
+import os
+
+# Устанавливаем необходимые переменные окружения для теста
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_KEY", "test")
+
+# Добавляем корень проекта в путь для импорта
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.message_processor import MessageProcessor
+
+
+class DummyFile:
+    def __init__(self, file_path: str, file_size: int = 1000):
+        self.file_path = file_path
+        self.file_size = file_size
+
+
+class DummyBot:
+    async def get_file(self, file_id: str) -> DummyFile:  # type: ignore[override]
+        return DummyFile(file_path=f"/tmp/{file_id}")
+
+
+async def run_test():
+    """Запускает проверки обработки голосового и фото сообщений"""
+    processor = MessageProcessor(bot=DummyBot())
+
+    # Заглушаем вызов OpenAI
+    async def fake_analyze(text: str) -> dict:
+        return {}
+
+    processor.openai_service.analyze_with_assistant = fake_analyze  # type: ignore
+
+    # Тест голосового сообщения
+    voice_message = SimpleNamespace(
+        voice=SimpleNamespace(file_id="voice123", duration=5),
+        photo=None,
+        audio=None,
+        document=None,
+        text=None,
+    )
+    voice_result = await processor._process_voice_message(voice_message)
+    print("Voice result:", voice_result)
+
+    # Тест фото сообщения
+    photo_obj = SimpleNamespace(file_id="photo123", file_size=500, width=100, height=100)
+    photo_message = SimpleNamespace(
+        photo=[photo_obj],
+        voice=None,
+        audio=None,
+        document=None,
+        text=None,
+    )
+    photo_result = await processor._process_photo_message(photo_message)
+    print("Photo result:", photo_result)
+
+
+if __name__ == "__main__":
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- add stub async converters (voice/audio/image/pdf) in media processor
- create manual test script to verify voice and photo handling via stubs

## Testing
- `python tests/test_media_messages.py`


------
https://chatgpt.com/codex/tasks/task_e_68be1b7d86e8832ca80553fff61b07c9