### PR TITLE
Fix summary sheet output and parser handling

### DIFF
--- a/pipeline/matching_engine.py
+++ b/pipeline/matching_engine.py
@@ -18,6 +18,7 @@ class MatchCandidate:
     name: str
     pack_qty: Optional[float]
     price: Optional[float]
+    unit: Optional[str]
     score: float
     explanation: str
     source: str  # rules/vector/gpt
@@ -105,6 +106,7 @@ class MatchingEngine:
                                 name=item['name'],
                                 pack_qty=item.get('pack_qty'),
                                 price=item.get('price'),
+                                unit=item.get('unit'),
                                 score=0.6,  # Высокий балл за точное совпадение алиаса
                                 explanation=f"Exact alias match: {alias['alias']} -> {alias_type}",
                                 source='rules'
@@ -129,8 +131,9 @@ class MatchingEngine:
                 candidate = MatchCandidate(
                     ku=item['sku'],
                     name=item['name'],
-                    pack_qty=item.get('pack_size'),
+                    pack_qty=item.get('pack_qty'),
                     price=item.get('price'),
+                    unit=item.get('unit'),
                     score=similarity,
                     explanation=f"Fuzzy match: {similarity:.2f} similarity",
                     source='rules'

--- a/pipeline/text_parser.py
+++ b/pipeline/text_parser.py
@@ -162,8 +162,8 @@ class TextParser:
         if not text:
             return []
         
-        # Split by common delimiters
-        lines = re.split(r'[\n;,\t]+', text)
+        # Split by common delimiters (comma removed to keep numbers like "4,0" intact)
+        lines = re.split(r'[\n;\t]+', text)
         
         parsed_lines = []
         for i, line in enumerate(lines, 1):

--- a/services/excel_generator_v2.py
+++ b/services/excel_generator_v2.py
@@ -61,8 +61,8 @@ class ExcelGeneratorV2:
         
         # Headers
         headers = [
-            "№", "Запрос", "KU", "Наименование", "Упаковка_pack_qty",
-            "Кол-во_уп", "Кол-во_шт", "Цена", "Сумма", "Статус"
+            "№", "Запрос", "SKU", "Наименование", "Упаковка_pack_qty",
+            "Единица_изм", "Кол-во_уп", "Кол-во_шт", "Цена", "Сумма", "Статус"
         ]
         
         # Write headers
@@ -74,27 +74,29 @@ class ExcelGeneratorV2:
         
         # Write data
         for row, result in enumerate(results, 2):
-            # Get item details if KU is chosen
+            # Get item details if SKU is chosen
             item_name = ""
             pack_qty = ""
-            price = ""
-            
+            unit = result.unit or ""
+
             if result.chosen_ku:
-                # This would normally come from database lookup
-                item_name = f"Item for {result.chosen_ku}"
-                pack_qty = "100"  # Placeholder
-                price = "10.50"   # Placeholder
-            
+                candidate = next((c for c in result.candidates if c.ku == result.chosen_ku), None)
+                if candidate:
+                    item_name = candidate.name
+                    pack_qty = candidate.pack_qty or ""
+                    unit = unit or (candidate.unit or "")
+
             sheet.cell(row=row, column=1, value=row - 1)  # №
             sheet.cell(row=row, column=2, value=result.raw_text)  # Запрос
-            sheet.cell(row=row, column=3, value=result.chosen_ku or "")  # KU
+            sheet.cell(row=row, column=3, value=result.chosen_ku or "")  # SKU
             sheet.cell(row=row, column=4, value=item_name)  # Наименование
             sheet.cell(row=row, column=5, value=pack_qty)  # Упаковка_pack_qty
-            sheet.cell(row=row, column=6, value=result.qty_packs or "")  # Кол-во_уп
-            sheet.cell(row=row, column=7, value=result.qty_units or "")  # Кол-во_шт
-            sheet.cell(row=row, column=8, value=price)  # Цена
-            sheet.cell(row=row, column=9, value=result.total or "")  # Сумма
-            sheet.cell(row=row, column=10, value=result.status)  # Статус
+            sheet.cell(row=row, column=6, value=unit)  # Единица_изм
+            sheet.cell(row=row, column=7, value=result.qty_packs or "")  # Кол-во_уп
+            sheet.cell(row=row, column=8, value=result.qty_units or "")  # Кол-во_шт
+            sheet.cell(row=row, column=9, value="")  # Цена
+            sheet.cell(row=row, column=10, value=result.total or "")  # Сумма
+            sheet.cell(row=row, column=11, value=result.status)  # Статус
     
     def _create_candidates_sheet(self, results: List[ProcessingResult]):
         """Create 'Кандидаты' sheet with all candidates"""
@@ -220,13 +222,13 @@ class ExcelGeneratorV2:
             if sheet_name == 'summary':
                 # Format price and total columns
                 for row in range(2, sheet.max_row + 1):
-                    # Price column (H)
-                    price_cell = sheet.cell(row=row, column=8)
+                    # Price column (I)
+                    price_cell = sheet.cell(row=row, column=9)
                     if price_cell.value:
                         price_cell.number_format = '#,##0.00'
-                    
-                    # Total column (I)
-                    total_cell = sheet.cell(row=row, column=9)
+
+                    # Total column (J)
+                    total_cell = sheet.cell(row=row, column=10)
                     if total_cell.value:
                         total_cell.number_format = '#,##0.00'
             

--- a/test_components_v2.py
+++ b/test_components_v2.py
@@ -113,6 +113,7 @@ async def test_gpt_validator():
             name='Болт DIN 933 кл.пр.8.8 М10х30, цинк',
             pack_qty=100,
             price=2.50,
+            unit='шт',
             score=0.85,
             explanation='Exact match',
             source='rules'
@@ -160,6 +161,7 @@ async def test_excel_generation():
             chosen_ku='BOLT-M10x30-8.8',
             qty_packs=2.0,
             qty_units=200.0,
+            unit='шт',
             price=2.50,
             total=500.0,
             status='ok',
@@ -170,6 +172,7 @@ async def test_excel_generation():
                     name='Болт DIN 933 кл.пр.8.8 М10х30, цинк',
                     pack_qty=100,
                     price=2.50,
+                    unit='шт',
                     score=0.95,
                     explanation='Exact match',
                     source='rules'

--- a/test_integration_v2.py
+++ b/test_integration_v2.py
@@ -126,6 +126,7 @@ async def test_gpt_validator():
             name='Болт DIN 933 кл.пр.8.8 М10х30, цинк',
             pack_qty=100,
             price=2.50,
+            unit='шт',
             score=0.85,
             explanation='Exact match',
             source='rules'
@@ -135,6 +136,7 @@ async def test_gpt_validator():
             name='Болт М10х30, цинк',
             pack_qty=50,
             price=2.20,
+            unit='шт',
             score=0.75,
             explanation='Similar match',
             source='rules'
@@ -183,6 +185,7 @@ async def test_excel_generation():
             chosen_ku='BOLT-M10x30-8.8',
             qty_packs=2.0,
             qty_units=200.0,
+            unit='шт',
             price=2.50,
             total=500.0,
             status='ok',
@@ -193,6 +196,7 @@ async def test_excel_generation():
                     name='Болт DIN 933 кл.пр.8.8 М10х30, цинк',
                     pack_qty=100,
                     price=2.50,
+                    unit='шт',
                     score=0.95,
                     explanation='Exact match',
                     source='rules'
@@ -206,6 +210,7 @@ async def test_excel_generation():
             chosen_ku='ANCHOR-M10x100',
             qty_packs=1.0,
             qty_units=25.0,
+            unit='шт',
             price=15.80,
             total=15.80,
             status='ok',
@@ -216,6 +221,7 @@ async def test_excel_generation():
                     name='Анкер клиновой оцинк. М10х100',
                     pack_qty=25,
                     price=15.80,
+                    unit='шт',
                     score=0.90,
                     explanation='Exact match',
                     source='rules'

--- a/tests/test_table_fixes.py
+++ b/tests/test_table_fixes.py
@@ -1,0 +1,64 @@
+import asyncio
+import os
+import sys
+from openpyxl import load_workbook
+
+# Ensure project root is on the Python path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Set required environment variables for imports
+os.environ.setdefault('TELEGRAM_BOT_TOKEN', 'test')
+os.environ.setdefault('OPENAI_API_KEY', 'test')
+os.environ.setdefault('SUPABASE_URL', 'http://localhost')
+os.environ.setdefault('SUPABASE_KEY', 'test')
+
+from services.excel_generator_v2 import ExcelGeneratorV2
+from pipeline.text_parser import TextParser
+from pipeline.processing_pipeline import ProcessingResult
+from pipeline.matching_engine import MatchCandidate
+
+def test_text_parser_preserves_commas():
+    parser = TextParser()
+    lines = parser.parse_text_input("Гвоздь строительный 4,0х120")
+    assert len(lines) == 1
+    assert "4,0х120" in lines[0].raw_text
+
+def test_excel_summary_headers_and_price_blank():
+    generator = ExcelGeneratorV2()
+    result = ProcessingResult(
+        line_id=1,
+        raw_text='Гвоздь строительный 4,0х120',
+        normalized_text='Гвоздь строительный 4,0х120',
+        chosen_ku='SKU123',
+        qty_packs=1,
+        qty_units=100,
+        unit='шт',
+        price=None,
+        total=None,
+        status='ok',
+        chosen_method='rules',
+        candidates=[
+            MatchCandidate(
+                ku='SKU123',
+                name='Гвоздь строительный 4,0х120',
+                pack_qty=100,
+                price=None,
+                unit='шт',
+                score=1.0,
+                explanation='',
+                source='rules'
+            )
+        ]
+    )
+    request_data = {'input_lines': [result.raw_text], 'source': 'text'}
+    file_path = asyncio.run(
+        generator.generate_excel('test', [result], request_data)
+    )
+    wb = load_workbook(file_path)
+    sheet = wb['Итог']
+    assert sheet.cell(1,3).value == 'SKU'
+    assert sheet.cell(1,6).value == 'Единица_изм'
+    assert sheet.cell(2,4).value == 'Гвоздь строительный 4,0х120'
+    assert sheet.cell(2,5).value == 100
+    assert sheet.cell(2,6).value == 'шт'
+    assert sheet.cell(2,9).value in (None, '')


### PR DESCRIPTION
## Summary
- Avoid splitting input lines on commas so values like `4,0х120` remain intact
- Populate Excel summary with SKU, unit of measurement and real item data while leaving price blank
- Track units in processing results and match candidates to support new column

## Testing
- `pytest tests/test_table_fixes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be24c074a8832c9efa8fb932613a73