### PR TITLE
Fix quantity parsing crash and strip list markers

### DIFF
--- a/pipeline/text_parser.py
+++ b/pipeline/text_parser.py
@@ -164,31 +164,33 @@ class TextParser:
         
         # Split by common delimiters (comma removed to keep numbers like "4,0" intact)
         lines = re.split(r'[\n;\t]+', text)
-        
+
         parsed_lines = []
         for i, line in enumerate(lines, 1):
             line = line.strip()
             if not line:
                 continue
-            
+
+            # Remove common bullet/list markers from the beginning of the line
+            line = re.sub(r'^[\-\*\u2022•]+\s*', '', line)
+
             # Normalize the line
             normalized = self.normalizer.normalize_text(line)
-            
+
             # Extract quantity
             qty, unit = self.normalizer.extract_quantity(line)
-            
+
             # Extract parameters
             params = self.normalizer.extract_parameters(normalized)
-            
-            # Calculate qty_units if we have qty_packs and pack_qty
+
+            # Calculate qty_units/qty_packs ensuring both variables are defined
+            qty_packs = None
             qty_units = None
             if qty and unit == 'шт':
                 qty_units = qty
             elif qty and unit == 'уп':
                 qty_packs = qty
-            else:
-                qty_packs = None
-            
+
             parsed_line = ParsedLine(
                 raw_text=line,
                 normalized_text=normalized,


### PR DESCRIPTION
## Summary
- Strip leading bullet and list characters from each input line
- Initialize qty_packs and qty_units to prevent crashes when quantity in pieces is parsed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pipeline')*

------
https://chatgpt.com/codex/tasks/task_e_68be28afcce4832c9a3f46988868715e