### PR TITLE
Fix missing context in V2 media handlers

### DIFF
--- a/handlers/message_handler_v2.py
+++ b/handlers/message_handler_v2.py
@@ -46,11 +46,11 @@ class MessageHandlerV2:
             if message.text:
                 await self._handle_text_message(message, user_id, chat_id)
             elif message.photo:
-                await self._handle_photo_message(message, user_id, chat_id)
+                await self._handle_photo_message(message, user_id, chat_id, context)
             elif message.voice:
-                await self._handle_voice_message(message, user_id, chat_id)
+                await self._handle_voice_message(message, user_id, chat_id, context)
             elif message.document:
-                await self._handle_document_message(message, user_id, chat_id)
+                await self._handle_document_message(message, user_id, chat_id, context)
             else:
                 await message.reply_text("❌ Неподдерживаемый тип сообщения")
                 return
@@ -106,7 +106,8 @@ class MessageHandlerV2:
             logger.error(f"Error handling text message: {e}")
             await message.reply_text("❌ Ошибка обработки текстового сообщения")
     
-    async def _handle_photo_message(self, message: Message, user_id: str, chat_id: str):
+    async def _handle_photo_message(self, message: Message, user_id: str, chat_id: str,
+                                    context: ContextTypes.DEFAULT_TYPE):
         """Handle photo messages with OCR"""
         try:
             # Get the highest resolution photo
@@ -161,7 +162,8 @@ class MessageHandlerV2:
             logger.error(f"Error handling photo message: {e}")
             await message.reply_text("❌ Ошибка обработки изображения")
     
-    async def _handle_voice_message(self, message: Message, user_id: str, chat_id: str):
+    async def _handle_voice_message(self, message: Message, user_id: str, chat_id: str,
+                                    context: ContextTypes.DEFAULT_TYPE):
         """Handle voice messages with speech-to-text"""
         try:
             # Get voice file
@@ -214,7 +216,8 @@ class MessageHandlerV2:
             logger.error(f"Error handling voice message: {e}")
             await message.reply_text("❌ Ошибка обработки голосового сообщения")
     
-    async def _handle_document_message(self, message: Message, user_id: str, chat_id: str):
+    async def _handle_document_message(self, message: Message, user_id: str, chat_id: str,
+                                       context: ContextTypes.DEFAULT_TYPE):
         """Handle document messages (Excel files)"""
         try:
             document = message.document


### PR DESCRIPTION
## Summary
- pass Telegram context to photo, voice, and document handlers in `MessageHandlerV2`
- ensure media downloads and processing on Railway deployment

## Testing
- `pytest -q` *(fails: async def functions are not natively supported; pytest-asyncio install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68be64b03b14832cb4f0276be9f566a9