### PR TITLE
Defer config validation for Telegram and Supabase

### DIFF
--- a/bot_railway.py
+++ b/bot_railway.py
@@ -48,6 +48,9 @@ except ImportError as e:
 def main():
     """Основная функция запуска бота"""
     try:
+        if not TELEGRAM_TOKEN:
+            raise ValueError("TELEGRAM_BOT_TOKEN не установлен в переменных окружения")
+
         # Получаем порт для Railway (всегда используем 8000)
         port = 8000
         logger.info(f"Запуск на порту: {port}")

--- a/bot_simple.py
+++ b/bot_simple.py
@@ -77,6 +77,9 @@ def main():
         # Получаем порт для Railway (если не указан, используем 8000)
         port = int(os.getenv('PORT', 8000))
         logger.info(f"Запуск на порту: {port}")
+
+        if not TELEGRAM_TOKEN:
+            raise ValueError("TELEGRAM_BOT_TOKEN не установлен в переменных окружения")
         
         # Создаем приложение
         application = Application.builder().token(TELEGRAM_TOKEN).build()

--- a/bot_webhook.py
+++ b/bot_webhook.py
@@ -48,6 +48,9 @@ except ImportError as e:
 def main():
     """Основная функция запуска бота с webhook"""
     try:
+        if not TELEGRAM_TOKEN:
+            raise ValueError("TELEGRAM_BOT_TOKEN не установлен в переменных окружения")
+
         # Получаем порт для Railway
         port = int(os.getenv('PORT', 8000))
         base_url = os.getenv('WEBHOOK_BASE', 'https://your-app.up.railway.app')

--- a/config.py
+++ b/config.py
@@ -12,10 +12,6 @@ load_dotenv()
 # Telegram Bot конфигурация
 TELEGRAM_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
 
-# Проверяем наличие обязательных переменных
-if not TELEGRAM_TOKEN:
-    raise ValueError("TELEGRAM_BOT_TOKEN не установлен в переменных окружения")
-
 # OpenAI конфигурация
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 OPENAI_MODEL = "gpt-4"
@@ -27,8 +23,20 @@ if not OPENAI_API_KEY:
 SUPABASE_URL = os.getenv('SUPABASE_URL')
 SUPABASE_KEY = os.getenv('SUPABASE_KEY')
 
-if not SUPABASE_URL or not SUPABASE_KEY:
-    raise ValueError("SUPABASE_URL и SUPABASE_KEY должны быть установлены в переменных окружения")
+def get_telegram_token() -> str:
+    """Возвращает токен Telegram бота, проверяя его наличие при обращении."""
+    token = os.getenv('TELEGRAM_BOT_TOKEN')
+    if not token:
+        raise ValueError("TELEGRAM_BOT_TOKEN не установлен в переменных окружения")
+    return token
+
+def get_supabase_credentials() -> tuple[str, str]:
+    """Возвращает настройки Supabase, проверяя их наличие при обращении."""
+    url = os.getenv('SUPABASE_URL')
+    key = os.getenv('SUPABASE_KEY')
+    if not url or not key:
+        raise ValueError("SUPABASE_URL и SUPABASE_KEY должны быть установлены в переменных окружения")
+    return url, key
 
 # Конфигурация базы данных
 DB_TABLES = {

--- a/test_minimal_bot.py
+++ b/test_minimal_bot.py
@@ -24,7 +24,10 @@ def main():
     """Основная функция"""
     try:
         logger.info("Запускаем минимальный бот...")
-        
+
+        if not TELEGRAM_TOKEN:
+            raise ValueError("TELEGRAM_BOT_TOKEN не установлен в переменных окружения")
+
         # Создаем приложение
         application = Application.builder().token(TELEGRAM_TOKEN).build()
         


### PR DESCRIPTION
## Summary
- Load TELEGRAM_BOT_TOKEN and Supabase settings without immediate validation
- Add helpers to validate Telegram token and Supabase credentials on demand
- Ensure bot scripts validate TELEGRAM_BOT_TOKEN only when executed

## Testing
- `OPENAI_API_KEY=test PYTHONPATH=. pytest` *(fails: async def functions are not natively supported)*
- `OPENAI_API_KEY=test python - <<'PY'
from services.openai_service import OpenAIService
OpenAIService()
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68be6ba74044832c81d388301f92caba