### PR TITLE
Log auto-accepted candidates

### DIFF
--- a/pipeline/processing_pipeline.py
+++ b/pipeline/processing_pipeline.py
@@ -124,6 +124,7 @@ class ProcessingPipeline:
 
             chosen_candidate = None
             if should_auto_accept and best_candidate:
+                logger.info("Auto-accepted candidate without GPT validation")
                 # Auto-accept
                 chosen_candidate = best_candidate
                 chosen_ku = best_candidate.ku


### PR DESCRIPTION
## Summary
- log when a candidate is auto-accepted without GPT validation in the processing pipeline

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pipeline'; ModuleNotFoundError: No module named 'config'; ValueError: TELEGRAM_BOT_TOKEN не установлен в переменных окружения)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ce5c184832cac2216b123f66173