### PR TITLE
Log GPT validation reason

### DIFF
--- a/services/gpt_validator.py
+++ b/services/gpt_validator.py
@@ -57,7 +57,9 @@ class GPTValidator:
             # Parse response
             result = self._parse_gpt_response(response)
             
-            logger.info(f"GPT validation result: {result.decision} (confidence: {result.confidence})")
+            logger.info(
+                f"GPT validation result: {result.decision} (confidence: {result.confidence}) reason: {result.reason}"
+            )
             
             return result
             


### PR DESCRIPTION
## Summary
- Log GPT result reasoning in validator output to capture decision rationale

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pipeline'; TELEGRAM_BOT_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ce9c088832ca116fe5397aef2ef