### PR TITLE
Fail fast on misconfigured GPT and Supabase

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,7 +14,7 @@ TELEGRAM_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
 
 # OpenAI конфигурация
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
-OPENAI_MODEL = "gpt-4"
+OPENAI_MODEL = os.getenv('OPENAI_MODEL', 'gpt-4')
 
 if not OPENAI_API_KEY:
     raise ValueError("OPENAI_API_KEY не установлен в переменных окружения")

--- a/services/openai_service.py
+++ b/services/openai_service.py
@@ -76,20 +76,7 @@ class OpenAIService:
                 
         except Exception as e:
             logger.error(f"Ошибка при анализе через GPT: {e}")
-            return {
-                "type": "неизвестно",
-                "diameter": None,
-                "length": None,
-                "material": None,
-                "coating": None,
-                "head_type": None,
-                "standard": None,
-                "quantity": None,
-                "additional_features": [],
-                "confidence": 0.0,
-                "raw_text": text,
-                "error": str(e)
-            }
+            raise
     
     async def search_query_optimization(self, user_intent: dict) -> str:
         """Оптимизирует поисковый запрос на основе анализа GPT"""


### PR DESCRIPTION
## Summary
- read OpenAI model from environment
- raise on GPT and Supabase misconfiguration instead of silent fallbacks
- return explicit `unknown` intent when basic parsing fails

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pipeline')*

------
https://chatgpt.com/codex/tasks/task_e_68be78a48f24832c9b743ec986d6469f